### PR TITLE
Add support for perfect mensuration at simultaneous note levels

### DIFF
--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -42,7 +42,7 @@ public:
      */
     ///@{
     std::vector<ArrayOfElementDurPairs> SubdivideIntoBoundedSequences(
-        const ArrayOfElementDurPairs &dursInVoiceSameMensur);
+        const ArrayOfElementDurPairs &dursInVoiceSameMensur, data_DURATION boundUnit);
     void ProcessBoundedSequences(const std::vector<ArrayOfElementDurPairs> &listOfSequences);
     void ProcessBoundedSequences(const ArrayOfElementDurPairs &sequence);
     ArrayOfElementDurPairs GetBoundedNotes(const ArrayOfElementDurPairs &sequence);

--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -41,6 +41,7 @@ public:
      * @name: Divide the notes of a voice into sequences to be processed individualy
      */
     ///@{
+    void workInMensur(const ArrayOfElementDurPairs &m_dursInVoiceSameMensur, data_DURATION noteLevel);
     std::vector<ArrayOfElementDurPairs> SubdivideIntoBoundedSequences(
         const ArrayOfElementDurPairs &dursInVoiceSameMensur, data_DURATION boundUnit);
     void ProcessBoundedSequences(const std::vector<ArrayOfElementDurPairs> &listOfSequences, data_DURATION boundUnit);

--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -76,6 +76,7 @@ public:
     Note *ImperfectionAPA(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
     Note *Alteration(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
     bool LeavePerfect(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
+    void ApplyAugmentationsAndPerfections();
     ///@}
 
     /*
@@ -96,6 +97,8 @@ private:
     int m_prolatio;
     ArrayOfElementDurPairs m_dursInVoiceSameMensur;
     std::vector<ArrayOfElementDurPairs> m_listOfSequences;
+    std::list<std::pair<Note*, Dot*>> m_listOfAugNotesDotsPairs;
+    std::list<std::pair<Note*, Dot*>> m_listOfPerfNotesDotsPairs;
 
 public:
     //

--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -54,8 +54,8 @@ public:
      * altera) for sequences with or without dots of division
      */
     ///@{
-    bool EvalDotOfDiv(const ArrayOfElementDurPairs &middleSeq, const ArrayOfElementDurPairs &sequence, int dotInd);
-    void FindDurQuals(const ArrayOfElementDurPairs &middleSeq, double valueInUnit);
+    bool EvalDotOfDiv(const ArrayOfElementDurPairs &middleSeq, const ArrayOfElementDurPairs &sequence, int dotInd, data_DURATION unit);
+    void FindDurQuals(const ArrayOfElementDurPairs &middleSeq, double valueInUnit, data_DURATION boundUnit);
     ///@}
 
     /**
@@ -72,10 +72,10 @@ public:
      * @name Apply the modifications of imperfection and alteration or leaves the notes with their default perfect value
      */
     ///@{
-    Note *ImperfectionAPP(const ArrayOfElementDurPairs &sequence);
-    Note *ImperfectionAPA(const ArrayOfElementDurPairs &sequence);
-    Note *Alteration(const ArrayOfElementDurPairs &sequence);
-    bool LeavePerfect(const ArrayOfElementDurPairs &sequence);
+    Note *ImperfectionAPP(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
+    Note *ImperfectionAPA(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
+    Note *Alteration(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
+    bool LeavePerfect(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
     ///@}
 
     /*

--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -43,9 +43,9 @@ public:
     ///@{
     std::vector<ArrayOfElementDurPairs> SubdivideIntoBoundedSequences(
         const ArrayOfElementDurPairs &dursInVoiceSameMensur, data_DURATION boundUnit);
-    void ProcessBoundedSequences(const std::vector<ArrayOfElementDurPairs> &listOfSequences);
-    void ProcessBoundedSequences(const ArrayOfElementDurPairs &sequence);
-    ArrayOfElementDurPairs GetBoundedNotes(const ArrayOfElementDurPairs &sequence);
+    void ProcessBoundedSequences(const std::vector<ArrayOfElementDurPairs> &listOfSequences, data_DURATION boundUnit);
+    void ProcessBoundedSequences(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
+    ArrayOfElementDurPairs GetBoundedNotes(const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit);
     ///@}
 
     /**

--- a/include/vrv/scoringupfunctor.h
+++ b/include/vrv/scoringupfunctor.h
@@ -54,7 +54,8 @@ public:
      * altera) for sequences with or without dots of division
      */
     ///@{
-    bool EvalDotOfDiv(const ArrayOfElementDurPairs &middleSeq, const ArrayOfElementDurPairs &sequence, int dotInd, data_DURATION unit);
+    bool EvalDotOfDiv(const ArrayOfElementDurPairs &middleSeq, const ArrayOfElementDurPairs &sequence, int dotInd,
+        data_DURATION unit);
     void FindDurQuals(const ArrayOfElementDurPairs &middleSeq, double valueInUnit, data_DURATION boundUnit);
     ///@}
 
@@ -97,8 +98,8 @@ private:
     int m_prolatio;
     ArrayOfElementDurPairs m_dursInVoiceSameMensur;
     std::vector<ArrayOfElementDurPairs> m_listOfSequences;
-    std::list<std::pair<Note*, Dot*>> m_listOfAugNotesDotsPairs;
-    std::list<std::pair<Note*, Dot*>> m_listOfPerfNotesDotsPairs;
+    std::list<std::pair<Note *, Dot *>> m_listOfAugNotesDotsPairs;
+    std::list<std::pair<Note *, Dot *>> m_listOfPerfNotesDotsPairs;
 
 public:
     //

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -47,8 +47,22 @@ FunctorCode ScoringUpFunctor::VisitLayer(Layer *layer)
     data_PROLATIO prolatio = m_currentMensur->GetProlatio();*/
     // Doesn't get it from the staffDef, right?//
     if (!m_dursInVoiceSameMensur.empty()) {
-        m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_brevis);
-        this->ProcessBoundedSequences(m_listOfSequences);
+        if (m_prolatio == 3) {
+            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_semibrevis);
+            this->ProcessBoundedSequences(m_listOfSequences);
+        }
+        if (m_tempus == 3) {
+            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_brevis);
+            this->ProcessBoundedSequences(m_listOfSequences);
+        }
+        if (m_modusMinor == 3) {
+            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_longa);
+            this->ProcessBoundedSequences(m_listOfSequences);
+        }
+        if (m_modusMaior == 3) {
+            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_maxima);
+            this->ProcessBoundedSequences(m_listOfSequences);
+        }
         m_dursInVoiceSameMensur = {}; // restart for next voice (layer)
     }
     return FUNCTOR_CONTINUE;

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -327,13 +327,16 @@ double ScoringUpFunctor::GetDurNumberValue(
         assert(note);
         durquality = note->GetDurQuality();
     }
-    // int longaDefaultVal = m_modusMinor * m_tempus * m_prolatio;
+    int longaDefaultVal = m_modusMinor * m_tempus * m_prolatio;
     int brevisDefaultVal = m_tempus * m_prolatio;
     int semibrevisDefaultVal = m_prolatio;
     double durnum = 0;
     switch (dur) {
         case DURATION_longa:
-            if (m_modusMinor == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
+            if (durquality == DURQUALITY_mensural_altera) {
+                durnum = 2 * longaDefaultVal;
+            }
+            else if (m_modusMinor == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
                 durnum = 3 * brevisDefaultVal;
                 if (m_modusMinor == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
@@ -351,7 +354,10 @@ double ScoringUpFunctor::GetDurNumberValue(
             }
             break;
         case DURATION_brevis:
-            if (m_tempus == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
+            if (durquality == DURQUALITY_mensural_altera) {
+                durnum = 2 * brevisDefaultVal;
+            }
+            else if (m_tempus == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
                 durnum = 3 * semibrevisDefaultVal;
                 if (m_tempus == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
@@ -369,7 +375,10 @@ double ScoringUpFunctor::GetDurNumberValue(
             }
             break;
         case DURATION_semibrevis:
-            if (m_prolatio == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
+            if (durquality == DURQUALITY_mensural_altera) {
+                durnum = 2 * semibrevisDefaultVal;
+            }
+            else if (m_prolatio == 3 || durquality == DURQUALITY_mensural_perfecta || followedByDot) {
                 durnum = 3;
                 if (m_prolatio == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
@@ -392,6 +401,9 @@ double ScoringUpFunctor::GetDurNumberValue(
                 // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                 Dot *dot = vrv_cast<Dot *>(nextElement);
                 m_listOfAugNotesDotsPairs.push_back({ note, dot });
+            }
+            else if (durquality == DURQUALITY_mensural_altera) {
+                durnum = 2;
             }
             else {
                 durnum = 1;
@@ -714,7 +726,7 @@ bool ScoringUpFunctor::EvalDotOfDiv(
             // This is a "dot of division"
             flagDotOfDiv = true;
             // Then it divides the sequence into the following two:
-            ArrayOfElementDurPairs seq1 = { sequence.begin(), sequence.begin() + dotInd + 1 };
+            ArrayOfElementDurPairs seq1 = { sequence.begin(), sequence.begin() + dotInd + 2 };
             ArrayOfElementDurPairs seq2 = { sequence.begin() + dotInd + 2, sequence.end() };
             // Encode the dot of division:
             LayerElement *dotElement = sequence.at(dotInd + 1).first;

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -47,7 +47,7 @@ FunctorCode ScoringUpFunctor::VisitLayer(Layer *layer)
     data_PROLATIO prolatio = m_currentMensur->GetProlatio();*/
     // Doesn't get it from the staffDef, right?//
     if (!m_dursInVoiceSameMensur.empty()) {
-        m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur);
+        m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_brevis);
         this->ProcessBoundedSequences(m_listOfSequences);
         m_dursInVoiceSameMensur = {}; // restart for next voice (layer)
     }
@@ -108,21 +108,67 @@ FunctorCode ScoringUpFunctor::VisitLayerElement(LayerElement *layerElement)
 // 1. Find the bounded sequences by dividing all the notes in a given mensuration and voice into sequences bounded by
 // "supposedly" perfect notes
 std::vector<ArrayOfElementDurPairs> ScoringUpFunctor::SubdivideIntoBoundedSequences(
-    const ArrayOfElementDurPairs &dursInVoiceSameMensur)
+    const ArrayOfElementDurPairs &dursInVoiceSameMensur, data_DURATION boundUnit)
 {
     std::vector<ArrayOfElementDurPairs> listOfBoundedSequences = {};
     ArrayOfElementDurPairs boundedSequence = {};
-    for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
-        data_DURATION dur = elementDurPair.second;
-        if (dur == DURATION_brevis || dur == DURATION_longa || dur == DURATION_maxima) {
-            boundedSequence.insert(boundedSequence.end(), elementDurPair);
-            listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
-            boundedSequence = { elementDurPair };
+
+    // Depending on the boundUnit which could be a semibrevis (when in major prolation), a breve (when in perfect tempus), a longa (when in perfect modus minor), or a maxima (when in perfect modus major). The boundaries become the boundUnit note and any note of a higher value:
+    if (boundUnit == DURATION_semibrevis) {
+        for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
+            data_DURATION dur = elementDurPair.second;
+            if (dur == DURATION_semibrevis || dur == DURATION_brevis || dur == DURATION_longa || dur == DURATION_maxima) {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+                listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
+                boundedSequence = { elementDurPair };
+            }
+            else {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+            }
+            LogDebug("dur is:", dur);
         }
-        else {
-            boundedSequence.insert(boundedSequence.end(), elementDurPair);
+    }
+    else if (boundUnit == DURATION_brevis) {
+        for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
+            data_DURATION dur = elementDurPair.second;
+            if (dur == DURATION_brevis || dur == DURATION_longa || dur == DURATION_maxima) {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+                listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
+                boundedSequence = { elementDurPair };
+            }
+            else {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+            }
+            LogDebug("dur is:", dur);
         }
-        LogDebug("dur is:", dur);
+    }
+    else if (boundUnit == DURATION_longa) {
+        for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
+            data_DURATION dur = elementDurPair.second;
+            if (dur == DURATION_longa || dur == DURATION_maxima) {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+                listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
+                boundedSequence = { elementDurPair };
+            }
+            else {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+            }
+            LogDebug("dur is:", dur);
+        }
+    }
+    else if (boundUnit == DURATION_maxima) {
+        for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
+            data_DURATION dur = elementDurPair.second;
+            if (dur == DURATION_maxima) {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+                listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
+                boundedSequence = { elementDurPair };
+            }
+            else {
+                boundedSequence.insert(boundedSequence.end(), elementDurPair);
+            }
+            LogDebug("dur is:", dur);
+        }
     }
     return listOfBoundedSequences;
 }

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -113,11 +113,14 @@ std::vector<ArrayOfElementDurPairs> ScoringUpFunctor::SubdivideIntoBoundedSequen
     std::vector<ArrayOfElementDurPairs> listOfBoundedSequences = {};
     ArrayOfElementDurPairs boundedSequence = {};
 
-    // Depending on the boundUnit which could be a semibrevis (when in major prolation), a breve (when in perfect tempus), a longa (when in perfect modus minor), or a maxima (when in perfect modus major). The boundaries become the boundUnit note and any note of a higher value:
+    // Depending on the boundUnit which could be a semibrevis (when in major prolation), a breve (when in perfect
+    // tempus), a longa (when in perfect modus minor), or a maxima (when in perfect modus major). The boundaries become
+    // the boundUnit note and any note of a higher value:
     if (boundUnit == DURATION_semibrevis) {
         for (std::pair<LayerElement *, data_DURATION> elementDurPair : dursInVoiceSameMensur) {
             data_DURATION dur = elementDurPair.second;
-            if (dur == DURATION_semibrevis || dur == DURATION_brevis || dur == DURATION_longa || dur == DURATION_maxima) {
+            if (dur == DURATION_semibrevis || dur == DURATION_brevis || dur == DURATION_longa
+                || dur == DURATION_maxima) {
                 boundedSequence.insert(boundedSequence.end(), elementDurPair);
                 listOfBoundedSequences.insert(listOfBoundedSequences.end(), boundedSequence);
                 boundedSequence = { elementDurPair };

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -48,24 +48,26 @@ FunctorCode ScoringUpFunctor::VisitLayer(Layer *layer)
     // Doesn't get it from the staffDef, right?//
     if (!m_dursInVoiceSameMensur.empty()) {
         if (m_prolatio == 3) {
-            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_semibrevis);
-            this->ProcessBoundedSequences(m_listOfSequences, DURATION_semibrevis);
+            workInMensur(m_dursInVoiceSameMensur, DURATION_semibrevis);
         }
         if (m_tempus == 3) {
-            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_brevis);
-            this->ProcessBoundedSequences(m_listOfSequences, DURATION_brevis);
+            workInMensur(m_dursInVoiceSameMensur, DURATION_brevis);
         }
         if (m_modusMinor == 3) {
-            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_longa);
-            this->ProcessBoundedSequences(m_listOfSequences, DURATION_longa);
+            workInMensur(m_dursInVoiceSameMensur, DURATION_longa);
         }
         if (m_modusMaior == 3) {
-            m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, DURATION_maxima);
-            this->ProcessBoundedSequences(m_listOfSequences, DURATION_maxima);
+            workInMensur(m_dursInVoiceSameMensur, DURATION_maxima);
         }
         m_dursInVoiceSameMensur = {}; // restart for next voice (layer)
     }
     return FUNCTOR_CONTINUE;
+}
+
+void ScoringUpFunctor::workInMensur(const ArrayOfElementDurPairs &m_dursInVoiceSameMensur, data_DURATION noteLevel)
+{
+    m_listOfSequences = this->SubdivideIntoBoundedSequences(m_dursInVoiceSameMensur, noteLevel);
+    this->ProcessBoundedSequences(m_listOfSequences, noteLevel);
 }
 
 FunctorCode ScoringUpFunctor::VisitLayerElement(LayerElement *layerElement)

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -338,11 +338,12 @@ double ScoringUpFunctor::GetDurNumberValue(
                 if (m_modusMinor == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfAugNotesDotsPairs.push_back({note, dot});
-                } else if (m_modusMinor == 3 && followedByDot) {
+                    m_listOfAugNotesDotsPairs.push_back({ note, dot });
+                }
+                else if (m_modusMinor == 3 && followedByDot) {
                     // Candidate for dot of perfection (<dot form="div"> and @dur.quality="perfecta")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfPerfNotesDotsPairs.push_back({note, dot});
+                    m_listOfPerfNotesDotsPairs.push_back({ note, dot });
                 }
             }
             else if (m_modusMinor == 2 || durquality == DURQUALITY_mensural_imperfecta) {
@@ -355,11 +356,12 @@ double ScoringUpFunctor::GetDurNumberValue(
                 if (m_tempus == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfAugNotesDotsPairs.push_back({note, dot});
-                } else if (m_tempus == 3 && followedByDot) {
+                    m_listOfAugNotesDotsPairs.push_back({ note, dot });
+                }
+                else if (m_tempus == 3 && followedByDot) {
                     // Candidate for dot of perfection (<dot form="div"> and @dur.quality="perfecta")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfPerfNotesDotsPairs.push_back({note, dot});
+                    m_listOfPerfNotesDotsPairs.push_back({ note, dot });
                 }
             }
             else if (m_tempus == 2 || durquality == DURQUALITY_mensural_imperfecta) {
@@ -372,11 +374,12 @@ double ScoringUpFunctor::GetDurNumberValue(
                 if (m_prolatio == 2 && followedByDot) {
                     // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfAugNotesDotsPairs.push_back({note, dot});
-                } else if (m_prolatio == 3 && followedByDot) {
+                    m_listOfAugNotesDotsPairs.push_back({ note, dot });
+                }
+                else if (m_prolatio == 3 && followedByDot) {
                     // Candidate for dot of perfection (<dot form="div"> and @dur.quality="perfecta")
                     Dot *dot = vrv_cast<Dot *>(nextElement);
-                    m_listOfPerfNotesDotsPairs.push_back({note, dot});
+                    m_listOfPerfNotesDotsPairs.push_back({ note, dot });
                 }
             }
             else if (m_prolatio == 2 || durquality == DURQUALITY_mensural_imperfecta) {
@@ -388,7 +391,7 @@ double ScoringUpFunctor::GetDurNumberValue(
                 durnum = 1.5;
                 // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                 Dot *dot = vrv_cast<Dot *>(nextElement);
-                m_listOfAugNotesDotsPairs.push_back({note, dot});
+                m_listOfAugNotesDotsPairs.push_back({ note, dot });
             }
             else {
                 durnum = 1;
@@ -399,7 +402,7 @@ double ScoringUpFunctor::GetDurNumberValue(
                 durnum = 0.75;
                 // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                 Dot *dot = vrv_cast<Dot *>(nextElement);
-                m_listOfAugNotesDotsPairs.push_back({note, dot});
+                m_listOfAugNotesDotsPairs.push_back({ note, dot });
             }
             else {
                 durnum = 0.5;
@@ -410,7 +413,7 @@ double ScoringUpFunctor::GetDurNumberValue(
                 durnum = 0.375;
                 // Candidate for augmentation (<dot form="aug"> and @num="2", @numbase="3")
                 Dot *dot = vrv_cast<Dot *>(nextElement);
-                m_listOfAugNotesDotsPairs.push_back({note, dot});
+                m_listOfAugNotesDotsPairs.push_back({ note, dot });
             }
             else {
                 durnum = 0.25;
@@ -465,7 +468,8 @@ double ScoringUpFunctor::GetValueInUnit(double valueInMinims, data_DURATION unit
 
 // Find the quality of notes by applying the "principles of imperfection and alteration" based on the number of notes
 // between a bounded sequence
-void ScoringUpFunctor::FindDurQuals(const ArrayOfElementDurPairs &sequence, double valueInSmallerUnit, data_DURATION boundUnit)
+void ScoringUpFunctor::FindDurQuals(
+    const ArrayOfElementDurPairs &sequence, double valueInSmallerUnit, data_DURATION boundUnit)
 {
     double sum = valueInSmallerUnit; // JUST IN THIS CASE
     int remainder = (int)sum % 3;
@@ -655,7 +659,9 @@ Note *ScoringUpFunctor::Alteration(const ArrayOfElementDurPairs &sequence, data_
     data_DURATION penultDur = penultElementDurPair.second;
     /// Evaluates what is the type of the penultimate element in the sequence. If it is a rest, it forbids Alteration
     /// (returns false). If it is a note, and the note is a 'semibrevis', it alters the note (and returns true).
-    std::map<data_DURATION, data_DURATION> nextSmallLevel = {{DURATION_maxima, DURATION_longa}, {DURATION_longa, DURATION_brevis}, {DURATION_brevis, DURATION_semibrevis}, {DURATION_semibrevis, DURATION_minima}};
+    std::map<data_DURATION, data_DURATION> nextSmallLevel
+        = { { DURATION_maxima, DURATION_longa }, { DURATION_longa, DURATION_brevis },
+              { DURATION_brevis, DURATION_semibrevis }, { DURATION_semibrevis, DURATION_minima } };
     data_DURATION smallerValue = nextSmallLevel[boundUnit];
     if (penultElement->Is(NOTE) && penultDur == smallerValue) {
         Note *penultNote = vrv_cast<Note *>(penultElement);
@@ -675,11 +681,13 @@ bool ScoringUpFunctor::LeavePerfect(const ArrayOfElementDurPairs &sequence, data
 }
 
 // 5. Apply augmentations (due to a dot of augmentation) and perfections (due to a dot of perfection)
-void ScoringUpFunctor::ApplyAugmentationsAndPerfections(){
-    for (std::pair<Note*, Dot*> pairNoteAndDot : m_listOfAugNotesDotsPairs) {
+void ScoringUpFunctor::ApplyAugmentationsAndPerfections()
+{
+    for (std::pair<Note *, Dot *> pairNoteAndDot : m_listOfAugNotesDotsPairs) {
         pairNoteAndDot.first->SetDurQuality(DURQUALITY_mensural_perfecta);
         pairNoteAndDot.second->SetForm(dotLog_FORM_aug);
-    }for (std::pair<Note*, Dot*> pairNoteAndDot : m_listOfPerfNotesDotsPairs) {
+    }
+    for (std::pair<Note *, Dot *> pairNoteAndDot : m_listOfPerfNotesDotsPairs) {
         pairNoteAndDot.first->SetDurQuality(DURQUALITY_mensural_perfecta);
         pairNoteAndDot.second->SetForm(dotLog_FORM_div);
     }
@@ -716,7 +724,8 @@ bool ScoringUpFunctor::EvalDotOfDiv(
             this->FindDurQuals(seq1, sum1, unit);
             this->FindDurQuals(seq2, sum2, unit);
             ApplyAugmentationsAndPerfections();
-        } else {
+        }
+        else {
             m_listOfAugNotesDotsPairs.clear();
             m_listOfPerfNotesDotsPairs.clear();
         }

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -317,24 +317,16 @@ double ScoringUpFunctor::GetValueInUnit(double valueInMinims, data_DURATION unit
 {
     double valueInUnit = 0.0;
     if (unit == DURATION_semibrevis) {
-        valueInUnit = valueInMinims / 2;
-        // imperfect mensur
-        // MISSING perfect mensur
+        valueInUnit = valueInMinims / m_prolatio;
     }
     else if (unit == DURATION_brevis) {
-        valueInUnit = valueInMinims / 4;
-        // imperfect mensur
-        // MISSING perfect mensur
+        valueInUnit = valueInMinims / (m_prolatio * m_tempus);
     }
     else if (unit == DURATION_longa) {
-        valueInUnit = valueInMinims / 8;
-        // imperfect mensur
-        // MISSING perfect mensur
+        valueInUnit = valueInMinims / (m_prolatio * m_tempus * m_modusMinor);
     }
     else if (unit == DURATION_maxima) {
-        valueInUnit = valueInMinims / 16;
-        // imperfect mensur
-        // MISSING perfect mensur
+        valueInUnit = valueInMinims / (m_prolatio * m_tempus * m_modusMinor * m_modusMaior);
     }
     return valueInUnit;
 }

--- a/src/scoringupfunctor.cpp
+++ b/src/scoringupfunctor.cpp
@@ -260,11 +260,11 @@ void ScoringUpFunctor::ProcessBoundedSequences(const ArrayOfElementDurPairs &seq
 ArrayOfElementDurPairs ScoringUpFunctor::GetBoundedNotes(
     const ArrayOfElementDurPairs &sequence, data_DURATION boundUnit)
 {
+    data_DURATION firstNoteDur;
     ArrayOfElementDurPairs middleSeq = {};
-
-    if (boundUnit == DURATION_semibrevis) {
-        if (sequence.size() >= 2) {
-            data_DURATION firstNoteDur = sequence.at(0).second;
+    if (sequence.size() >= 2) {
+        if (boundUnit == DURATION_semibrevis) {
+            firstNoteDur = sequence.at(0).second;
             if (firstNoteDur == DURATION_minima || firstNoteDur == DURATION_semiminima || firstNoteDur == DURATION_fusa
                 || firstNoteDur == DURATION_semifusa) {
                 middleSeq = { sequence.begin(), sequence.end() - 1 };
@@ -273,10 +273,8 @@ ArrayOfElementDurPairs ScoringUpFunctor::GetBoundedNotes(
                 middleSeq = { sequence.begin() + 1, sequence.end() - 1 };
             }
         }
-    }
-    else if (boundUnit == DURATION_brevis) {
-        if (sequence.size() >= 2) {
-            data_DURATION firstNoteDur = sequence.at(0).second;
+        else if (boundUnit == DURATION_brevis) {
+            firstNoteDur = sequence.at(0).second;
             if (firstNoteDur == DURATION_semibrevis || firstNoteDur == DURATION_minima
                 || firstNoteDur == DURATION_semiminima || firstNoteDur == DURATION_fusa
                 || firstNoteDur == DURATION_semifusa) {
@@ -286,10 +284,8 @@ ArrayOfElementDurPairs ScoringUpFunctor::GetBoundedNotes(
                 middleSeq = { sequence.begin() + 1, sequence.end() - 1 };
             }
         }
-    }
-    else if (boundUnit == DURATION_longa) {
-        if (sequence.size() >= 2) {
-            data_DURATION firstNoteDur = sequence.at(0).second;
+        else if (boundUnit == DURATION_longa) {
+            firstNoteDur = sequence.at(0).second;
             if (firstNoteDur == DURATION_brevis || firstNoteDur == DURATION_semibrevis
                 || firstNoteDur == DURATION_minima || firstNoteDur == DURATION_semiminima
                 || firstNoteDur == DURATION_fusa || firstNoteDur == DURATION_semifusa) {
@@ -299,10 +295,8 @@ ArrayOfElementDurPairs ScoringUpFunctor::GetBoundedNotes(
                 middleSeq = { sequence.begin() + 1, sequence.end() - 1 };
             }
         }
-    }
-    else if (boundUnit == DURATION_maxima) {
-        if (sequence.size() >= 2) {
-            data_DURATION firstNoteDur = sequence.at(0).second;
+        else if (boundUnit == DURATION_maxima) {
+            firstNoteDur = sequence.at(0).second;
             if (firstNoteDur == DURATION_longa || firstNoteDur == DURATION_brevis || firstNoteDur == DURATION_semibrevis
                 || firstNoteDur == DURATION_minima || firstNoteDur == DURATION_semiminima
                 || firstNoteDur == DURATION_fusa || firstNoteDur == DURATION_semifusa) {


### PR DESCRIPTION
Tested with `modusminor = 3` and `tempus = 3`

[Tempus3Modus3.zip](https://github.com/user-attachments/files/17448278/Tempus3Modus3.zip)
